### PR TITLE
Use logrus' RegisterExitHandler() to wait for in-flight requests

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -3,8 +3,8 @@ package main
 import (
 	"time"
 
-	"github.com/knq/sdhook"
 	"github.com/sirupsen/logrus"
+	"github.com/thermeon/sdhook"
 )
 
 func main() {


### PR DESCRIPTION
Also remove the special handling for Panic. 

Using this, if we assume that applications will always exit using `logrus.Exit()`/`logrus.Fatal()`, then `logrus` will wait for the exit handler to finish before exiting the application.